### PR TITLE
make instancetype a jsonvalue

### DIFF
--- a/api/src/main/java/io/github/sebastiantoepfer/jsonschema/InstanceType.java
+++ b/api/src/main/java/io/github/sebastiantoepfer/jsonschema/InstanceType.java
@@ -24,6 +24,7 @@
 package io.github.sebastiantoepfer.jsonschema;
 
 import jakarta.json.JsonNumber;
+import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -33,7 +34,7 @@ import java.util.Locale;
 /**
  * see: http://json-schema.org/draft/2020-12/json-schema-core.html#name-instance-data-model
  */
-public enum InstanceType {
+public enum InstanceType implements JsonString {
     NULL(JsonValue.ValueType.NULL),
     BOOLEAN(JsonValue.ValueType.TRUE, JsonValue.ValueType.FALSE),
     OBJECT(JsonValue.ValueType.OBJECT),
@@ -74,6 +75,21 @@ public enum InstanceType {
 
     @Override
     public String toString() {
+        return getString();
+    }
+
+    @Override
+    public CharSequence getChars() {
+        return getString();
+    }
+
+    @Override
+    public String getString() {
         return name().toLowerCase(Locale.US);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return JsonValue.ValueType.STRING;
     }
 }

--- a/api/src/test/java/io/github/sebastiantoepfer/jsonschema/InstanceTypeTest.java
+++ b/api/src/test/java/io/github/sebastiantoepfer/jsonschema/InstanceTypeTest.java
@@ -24,6 +24,7 @@
 package io.github.sebastiantoepfer.jsonschema;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -92,6 +93,16 @@ class InstanceTypeTest {
             arguments(InstanceType.NUMBER, "number"),
             arguments(InstanceType.INTEGER, "integer")
         );
+    }
+
+    @Test
+    void should_be_from_json_type_string() {
+        assertThat(InstanceType.INTEGER.getValueType(), is(JsonValue.ValueType.STRING));
+    }
+
+    @Test
+    void should_retrun_his_value_as_charsquence() {
+        assertThat(InstanceType.INTEGER.getChars(), hasToString("integer"));
     }
 
     @Test


### PR DESCRIPTION
this allow to use instancetype to define a schema like:

` ...add("type", InstanceType.STRING)`
instead of
`...add("type", "string")`
or
`...add("type", InstanceType.STRING.toString())`