### PR TITLE
improve definition of keyword relationships (affects and affectedBy)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,14 +81,7 @@
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
+                        </dependency>
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
@@ -98,6 +91,17 @@
             <groupId>io.github.sebastian-toepfer.ddd</groupId>
             <artifactId>media-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectByType.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectByType.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
+
+public enum AffectByType {
+    EXTENDS {
+        @Override
+        Keyword affect(final Keyword affectedKeyword) {
+            return affectedKeyword;
+        }
+    },
+    REPLACE {
+        @Override
+        Keyword affect(final Keyword affectedKeyword) {
+            return new ReplacingKeyword(affectedKeyword);
+        }
+    };
+
+    abstract Keyword affect(final Keyword affectedKeyword);
+}

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectedBy.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectedBy.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import io.github.sebastiantoepfer.jsonschema.JsonSchema;
+import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+public final class AffectedBy implements Comparable<AffectedBy> {
+
+    private final AffectByType type;
+    private final String name;
+
+    public AffectedBy(final AffectByType type, final String name) {
+        this.type = Objects.requireNonNull(type);
+        this.name = Objects.requireNonNull(name);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 83 * hash + Objects.hashCode(this.type);
+        hash = 83 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return compareTo((AffectedBy) obj) == 0;
+    }
+
+    @Override
+    public int compareTo(final AffectedBy other) {
+        final int result;
+        if (type.compareTo(other.type) == 0) {
+            result = name.compareTo(other.name);
+        } else {
+            result = type.compareTo(other.type);
+        }
+        return result;
+    }
+
+    Function<Keyword, Keyword> findAffectedByKeywordIn(final JsonSchema schema) {
+        final UnaryOperator<Keyword> result;
+        if (schema.keywordByName(name).isPresent()) {
+            result = type::affect;
+        } else {
+            result = k -> k;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AffectedBy{" + "type=" + type + ", name=" + name + '}';
+    }
+}

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectedByKeywordType.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectedByKeywordType.java
@@ -33,7 +33,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Function;
 
-public class AffectedByKeywordType implements KeywordType {
+public final class AffectedByKeywordType implements KeywordType {
 
     private final String name;
     private final Collection<AffectedBy> affectedBy;
@@ -44,6 +44,9 @@ public class AffectedByKeywordType implements KeywordType {
         final Collection<AffectedBy> affectedBy,
         final Function<JsonSchema, Keyword> keywordCreator
     ) {
+        if (affectedBy.isEmpty()) {
+            throw new IllegalArgumentException("affectedBy can not be empty!");
+        }
         this.name = Objects.requireNonNull(name);
         this.affectedBy = List.copyOf(affectedBy);
         this.keywordCreator = Objects.requireNonNull(keywordCreator);

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/Affects.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/Affects.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import io.github.sebastiantoepfer.jsonschema.JsonSchema;
+import io.github.sebastiantoepfer.jsonschema.keyword.Annotation;
+import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
+import io.github.sebastiantoepfer.jsonschema.keyword.StaticAnnotation;
+import jakarta.json.JsonValue;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class Affects {
+
+    private final String name;
+    private final AbsenceStrategy strategy;
+
+    public Affects(final String name, final JsonValue answerInAbsence) {
+        this(name, new ProvideDefaultValue(answerInAbsence));
+    }
+
+    public Affects(final String name, final AbsenceStrategy strategy) {
+        this.name = Objects.requireNonNull(name);
+        this.strategy = Objects.requireNonNull(strategy);
+    }
+
+    @Override
+    public String toString() {
+        return "Affects{" + "name=" + name + ", strategy=" + strategy.getClass() + '}';
+    }
+
+    Map.Entry<Annotation, Function<Keyword, Keyword>> findAffectsKeywordIn(final JsonSchema schema) {
+        final Map.Entry<Annotation, Function<Keyword, Keyword>> result;
+        final Optional<Annotation> annotation = schema
+            .keywordByName(name)
+            .filter(k -> k.hasCategory(Keyword.KeywordCategory.ANNOTATION))
+            .map(Keyword::asAnnotation);
+        if (annotation.isPresent()) {
+            result = Map.entry(annotation.get(), k -> k);
+        } else {
+            result = strategy.create(name);
+        }
+        return result;
+    }
+
+    public interface AbsenceStrategy {
+        Map.Entry<Annotation, Function<Keyword, Keyword>> create(String name);
+    }
+
+    public static final class ReplaceKeyword implements AbsenceStrategy {
+
+        @Override
+        public Map.Entry<Annotation, Function<Keyword, Keyword>> create(final String name) {
+            return Map.entry(new StaticAnnotation(name, JsonValue.NULL), ReplacingKeyword::new);
+        }
+    }
+
+    public static final class ProvideDefaultValue implements AbsenceStrategy {
+
+        private final JsonValue answerInAbsence;
+
+        public ProvideDefaultValue(final JsonValue answerInAbsence) {
+            this.answerInAbsence = Objects.requireNonNullElse(answerInAbsence, JsonValue.NULL);
+        }
+
+        @Override
+        public Map.Entry<Annotation, Function<Keyword, Keyword>> create(final String name) {
+            return Map.entry(new StaticAnnotation(name, answerInAbsence), k -> k);
+        }
+    }
+}

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/ReplacingKeyword.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/ReplacingKeyword.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toSet;
+
+import io.github.sebastiantoepfer.ddd.common.Media;
+import io.github.sebastiantoepfer.jsonschema.keyword.Annotation;
+import io.github.sebastiantoepfer.jsonschema.keyword.Applicator;
+import io.github.sebastiantoepfer.jsonschema.keyword.Assertion;
+import io.github.sebastiantoepfer.jsonschema.keyword.Identifier;
+import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
+import io.github.sebastiantoepfer.jsonschema.keyword.ReservedLocation;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+final class ReplacingKeyword implements Keyword {
+
+    private final Keyword affectedKeyword;
+    private final Collection<KeywordCategory> categoriesToReplace;
+
+    public ReplacingKeyword(final Keyword affectedKeyword) {
+        this(affectedKeyword, EnumSet.of(KeywordCategory.APPLICATOR, KeywordCategory.ASSERTION));
+    }
+
+    public ReplacingKeyword(final Keyword affectedKeyword, final Collection<KeywordCategory> categoriesToReplace) {
+        this.affectedKeyword = Objects.requireNonNull(affectedKeyword);
+        this.categoriesToReplace = List.copyOf(categoriesToReplace);
+    }
+
+    @Override
+    public Identifier asIdentifier() {
+        if (categoriesToReplace.contains(KeywordCategory.IDENTIFIER)) {
+            throw new UnsupportedOperationException();
+        } else {
+            return affectedKeyword.asIdentifier();
+        }
+    }
+
+    @Override
+    public Assertion asAssertion() {
+        if (categoriesToReplace.contains(KeywordCategory.ASSERTION)) {
+            throw new UnsupportedOperationException();
+        } else {
+            return affectedKeyword.asAssertion();
+        }
+    }
+
+    @Override
+    public Annotation asAnnotation() {
+        if (categoriesToReplace.contains(KeywordCategory.ANNOTATION)) {
+            throw new UnsupportedOperationException();
+        } else {
+            return affectedKeyword.asAnnotation();
+        }
+    }
+
+    @Override
+    public Applicator asApplicator() {
+        if (categoriesToReplace.contains(KeywordCategory.APPLICATOR)) {
+            throw new UnsupportedOperationException();
+        } else {
+            return affectedKeyword.asApplicator();
+        }
+    }
+
+    @Override
+    public ReservedLocation asReservedLocation() {
+        if (categoriesToReplace.contains(KeywordCategory.RESERVED_LOCATION)) {
+            throw new UnsupportedOperationException();
+        } else {
+            return affectedKeyword.asReservedLocation();
+        }
+    }
+
+    @Override
+    public Collection<Keyword.KeywordCategory> categories() {
+        return affectedKeyword.categories().stream().filter(not(categoriesToReplace::contains)).collect(toSet());
+    }
+
+    @Override
+    public boolean hasName(final String string) {
+        return affectedKeyword.hasName(string);
+    }
+
+    @Override
+    public <T extends Media<T>> T printOn(final T media) {
+        return affectedKeyword.printOn(media);
+    }
+}

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/ReplacingKeyword.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/ReplacingKeyword.java
@@ -40,15 +40,15 @@ import java.util.Objects;
 
 final class ReplacingKeyword implements Keyword {
 
-    private final Keyword affectedKeyword;
+    private final Keyword keywordToReplace;
     private final Collection<KeywordCategory> categoriesToReplace;
 
-    public ReplacingKeyword(final Keyword affectedKeyword) {
-        this(affectedKeyword, EnumSet.of(KeywordCategory.APPLICATOR, KeywordCategory.ASSERTION));
+    public ReplacingKeyword(final Keyword keywordToReplace) {
+        this(keywordToReplace, EnumSet.of(KeywordCategory.APPLICATOR, KeywordCategory.ASSERTION));
     }
 
-    public ReplacingKeyword(final Keyword affectedKeyword, final Collection<KeywordCategory> categoriesToReplace) {
-        this.affectedKeyword = Objects.requireNonNull(affectedKeyword);
+    public ReplacingKeyword(final Keyword keywordToReplace, final Collection<KeywordCategory> categoriesToReplace) {
+        this.keywordToReplace = Objects.requireNonNull(keywordToReplace);
         this.categoriesToReplace = List.copyOf(categoriesToReplace);
     }
 
@@ -57,7 +57,7 @@ final class ReplacingKeyword implements Keyword {
         if (categoriesToReplace.contains(KeywordCategory.IDENTIFIER)) {
             throw new UnsupportedOperationException();
         } else {
-            return affectedKeyword.asIdentifier();
+            return keywordToReplace.asIdentifier();
         }
     }
 
@@ -66,7 +66,7 @@ final class ReplacingKeyword implements Keyword {
         if (categoriesToReplace.contains(KeywordCategory.ASSERTION)) {
             throw new UnsupportedOperationException();
         } else {
-            return affectedKeyword.asAssertion();
+            return keywordToReplace.asAssertion();
         }
     }
 
@@ -75,7 +75,7 @@ final class ReplacingKeyword implements Keyword {
         if (categoriesToReplace.contains(KeywordCategory.ANNOTATION)) {
             throw new UnsupportedOperationException();
         } else {
-            return affectedKeyword.asAnnotation();
+            return keywordToReplace.asAnnotation();
         }
     }
 
@@ -84,7 +84,7 @@ final class ReplacingKeyword implements Keyword {
         if (categoriesToReplace.contains(KeywordCategory.APPLICATOR)) {
             throw new UnsupportedOperationException();
         } else {
-            return affectedKeyword.asApplicator();
+            return keywordToReplace.asApplicator();
         }
     }
 
@@ -93,22 +93,22 @@ final class ReplacingKeyword implements Keyword {
         if (categoriesToReplace.contains(KeywordCategory.RESERVED_LOCATION)) {
             throw new UnsupportedOperationException();
         } else {
-            return affectedKeyword.asReservedLocation();
+            return keywordToReplace.asReservedLocation();
         }
     }
 
     @Override
     public Collection<Keyword.KeywordCategory> categories() {
-        return affectedKeyword.categories().stream().filter(not(categoriesToReplace::contains)).collect(toSet());
+        return keywordToReplace.categories().stream().filter(not(categoriesToReplace::contains)).collect(toSet());
     }
 
     @Override
     public boolean hasName(final String string) {
-        return affectedKeyword.hasName(string);
+        return keywordToReplace.hasName(string);
     }
 
     @Override
     public <T extends Media<T>> T printOn(final T media) {
-        return affectedKeyword.printOn(media);
+        return keywordToReplace.printOn(media);
     }
 }

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ApplicatorVocabulary.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ApplicatorVocabulary.java
@@ -24,6 +24,8 @@
 package io.github.sebastiantoepfer.jsonschema.core.vocab.applicator;
 
 import io.github.sebastiantoepfer.jsonschema.Vocabulary;
+import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectByType;
+import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectedBy;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectedByKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.NamedJsonSchemaKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.SchemaArrayKeywordType;
@@ -56,12 +58,14 @@ public final class ApplicatorVocabulary implements Vocabulary {
             new NamedJsonSchemaKeywordType(PatternPropertiesKeyword.NAME, PatternPropertiesKeyword::new),
             new SubSchemaKeywordType(ItemsKeyword.NAME, ItemsKeyword::new),
             new SchemaArrayKeywordType(PrefixItemsKeyword.NAME, PrefixItemsKeyword::new),
-            //normally affeced by minContains and maxContains, but only min has a direct effect!
+            new ArraySubSchemaKeywordType(PrefixItemsKeyword.NAME, PrefixItemsKeyword::new),
             new AffectedByKeywordType(
                 ContainsKeyword.NAME,
-                List.of("minContains"),
-                (a, schema) ->
-                    new SubSchemaKeywordType(ContainsKeyword.NAME, s -> new ContainsKeyword(a, s)).createKeyword(schema)
+                List.of(
+                    new AffectedBy(AffectByType.REPLACE, "minContains"),
+                    new AffectedBy(AffectByType.EXTENDS, "maxContains")
+                ),
+                new SubSchemaKeywordType(ContainsKeyword.NAME, ContainsKeyword::new)::createKeyword
             )
         );
     }

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ApplicatorVocabulary.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ApplicatorVocabulary.java
@@ -58,7 +58,7 @@ public final class ApplicatorVocabulary implements Vocabulary {
             new NamedJsonSchemaKeywordType(PatternPropertiesKeyword.NAME, PatternPropertiesKeyword::new),
             new SubSchemaKeywordType(ItemsKeyword.NAME, ItemsKeyword::new),
             new SchemaArrayKeywordType(PrefixItemsKeyword.NAME, PrefixItemsKeyword::new),
-            new ArraySubSchemaKeywordType(PrefixItemsKeyword.NAME, PrefixItemsKeyword::new),
+            new SchemaArrayKeywordType(PrefixItemsKeyword.NAME, PrefixItemsKeyword::new),
             new AffectedByKeywordType(
                 ContainsKeyword.NAME,
                 List.of(

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ContainsKeyword.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ContainsKeyword.java
@@ -30,7 +30,6 @@ import io.github.sebastiantoepfer.jsonschema.InstanceType;
 import io.github.sebastiantoepfer.jsonschema.JsonSchema;
 import io.github.sebastiantoepfer.jsonschema.keyword.Annotation;
 import io.github.sebastiantoepfer.jsonschema.keyword.Applicator;
-import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonValue;
 import java.util.Collection;
@@ -54,10 +53,8 @@ final class ContainsKeyword implements Applicator, Annotation {
 
     static final String NAME = "contains";
     private final JsonSchema contains;
-    private final List<Keyword> affectedBy;
 
-    public ContainsKeyword(final List<Keyword> affectedBy, final JsonSchema contains) {
-        this.affectedBy = List.copyOf(affectedBy);
+    public ContainsKeyword(final JsonSchema contains) {
         this.contains = Objects.requireNonNull(contains);
     }
 
@@ -82,7 +79,7 @@ final class ContainsKeyword implements Applicator, Annotation {
     }
 
     private boolean contains(final JsonArray array) {
-        return !affectedBy.isEmpty() || matchingValues(array).findAny().isPresent();
+        return matchingValues(array).findAny().isPresent();
     }
 
     @Override

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/MaxContainsKeyword.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/MaxContainsKeyword.java
@@ -30,6 +30,8 @@ import io.github.sebastiantoepfer.jsonschema.keyword.Assertion;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonValue;
 import java.math.BigInteger;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -47,11 +49,11 @@ import java.util.Objects;
 final class MaxContainsKeyword implements Assertion {
 
     static final String NAME = "maxContains";
-    private final Annotation affects;
+    private final Collection<Annotation> affects;
     private final BigInteger maxContains;
 
-    public MaxContainsKeyword(final Annotation affects, final BigInteger maxContains) {
-        this.affects = Objects.requireNonNull(affects);
+    public MaxContainsKeyword(final Collection<Annotation> affects, final BigInteger maxContains) {
+        this.affects = List.copyOf(affects);
         this.maxContains = Objects.requireNonNull(maxContains);
     }
 
@@ -67,20 +69,21 @@ final class MaxContainsKeyword implements Assertion {
 
     @Override
     public boolean isValidFor(final JsonValue instance) {
-        return (
-            !InstanceType.ARRAY.isInstance(instance) || isValidFor(affects.valueFor(instance), instance.asJsonArray())
+        return (!InstanceType.ARRAY.isInstance(instance) || isValidFor(instance.asJsonArray()));
+    }
+
+    private boolean isValidFor(final JsonArray instance) {
+        return isValidFor(
+            affects
+                .stream()
+                .map(a -> a.valueFor(instance))
+                .map(v -> new NumberOfMatches(instance, v))
+                .mapToInt(NumberOfMatches::count)
+                .sum()
         );
     }
 
-    private boolean isValidFor(final JsonValue containing, final JsonArray values) {
-        final boolean result;
-        if (JsonValue.NULL.equals(containing)) {
-            result = true;
-        } else if (JsonValue.TRUE.equals(containing)) {
-            result = values.size() <= maxContains.intValue();
-        } else {
-            result = containing.asJsonArray().size() <= maxContains.intValue();
-        }
-        return result;
+    private boolean isValidFor(final int containing) {
+        return containing <= maxContains.intValue();
     }
 }

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/NumberOfMatches.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/NumberOfMatches.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.vocab.validation;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
+import java.util.Objects;
+
+final class NumberOfMatches {
+
+    private final JsonArray array;
+    private final JsonValue value;
+
+    public NumberOfMatches(final JsonArray array, final JsonValue value) {
+        this.array = Objects.requireNonNull(array);
+        this.value = Objects.requireNonNull(value);
+    }
+
+    public int count() {
+        return value == JsonValue.TRUE ? array.size() : value.asJsonArray().size();
+    }
+}

--- a/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/ValidationVocabulary.java
+++ b/core/src/main/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/ValidationVocabulary.java
@@ -24,6 +24,7 @@
 package io.github.sebastiantoepfer.jsonschema.core.vocab.validation;
 
 import io.github.sebastiantoepfer.jsonschema.Vocabulary;
+import io.github.sebastiantoepfer.jsonschema.core.keyword.type.Affects;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectsKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AnyKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.ArrayKeywordType;
@@ -37,6 +38,7 @@ import io.github.sebastiantoepfer.jsonschema.keyword.KeywordType;
 import io.github.sebastiantoepfer.jsonschema.vocabulary.spi.DefaultVocabulary;
 import jakarta.json.spi.JsonProvider;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 public final class ValidationVocabulary implements Vocabulary {
@@ -65,7 +67,7 @@ public final class ValidationVocabulary implements Vocabulary {
             new IntegerKeywordType(jsonContext, MinItemsKeyword.NAME, MinItemsKeyword::new),
             new AffectsKeywordType(
                 MaxContainsKeyword.NAME,
-                "contains",
+                List.of(new Affects("contains", new Affects.ReplaceKeyword())),
                 (affects, schema) ->
                     new IntegerKeywordType(
                         JsonProvider.provider(),
@@ -75,13 +77,13 @@ public final class ValidationVocabulary implements Vocabulary {
             ),
             new AffectsKeywordType(
                 MinContainsKeyword.NAME,
-                "contains",
-                (a, s) ->
+                List.of(new Affects("contains", new Affects.ReplaceKeyword())),
+                (affects, schema) ->
                     new IntegerKeywordType(
                         JsonProvider.provider(),
                         MinContainsKeyword.NAME,
-                        value -> new MinContainsKeyword(a, value)
-                    ).createKeyword(s)
+                        value -> new MinContainsKeyword(affects, value)
+                    ).createKeyword(schema)
             ),
             new BooleanKeywordType(jsonContext, UniqueItemsKeyword.NAME, UniqueItemsKeyword::new)
         );

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectedByTest.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectedByTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.List;
+import java.util.TreeSet;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class AffectedByTest {
+
+    @Test
+    void should_fullfil_equals_contract() {
+        EqualsVerifier.forClass(AffectedBy.class).withNonnullFields("type", "name").verify();
+    }
+
+    @Test
+    void should_be_sorted_correctly() {
+        assertThat(
+            new TreeSet<>(
+                List.of(
+                    new AffectedBy(AffectByType.REPLACE, "d"),
+                    new AffectedBy(AffectByType.EXTENDS, "c"),
+                    new AffectedBy(AffectByType.EXTENDS, "b"),
+                    new AffectedBy(AffectByType.REPLACE, "a")
+                )
+            ),
+            contains(
+                new AffectedBy(AffectByType.EXTENDS, "b"),
+                new AffectedBy(AffectByType.EXTENDS, "c"),
+                new AffectedBy(AffectByType.REPLACE, "a"),
+                new AffectedBy(AffectByType.REPLACE, "d")
+            )
+        );
+    }
+}

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectsTest.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/AffectsTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.github.sebastiantoepfer.jsonschema.JsonSchemas;
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+import org.junit.jupiter.api.Test;
+
+class AffectsTest {
+
+    @Test
+    void should_handle_non_annotation_as_absence() {
+        assertThat(
+            new Affects("type", new Affects.ProvideDefaultValue(JsonValue.EMPTY_JSON_OBJECT))
+                .findAffectsKeywordIn(JsonSchemas.load(Json.createObjectBuilder().add("type", "number").build()))
+                .getKey()
+                .valueFor(JsonValue.FALSE),
+            is(JsonValue.EMPTY_JSON_OBJECT)
+        );
+    }
+
+    @Test
+    void should_return_original_annotation() {
+        assertThat(
+            new Affects("properties", new Affects.ProvideDefaultValue(JsonValue.EMPTY_JSON_OBJECT))
+                .findAffectsKeywordIn(
+                    JsonSchemas.load(
+                        Json.createObjectBuilder()
+                            .add(
+                                "properties",
+                                Json.createObjectBuilder().add("test", Json.createObjectBuilder().add("type", "number"))
+                            )
+                            .build()
+                    )
+                )
+                .getKey()
+                .valueFor(Json.createObjectBuilder().add("test", 1L).build()),
+            is(Json.createArrayBuilder().add("test").build())
+        );
+    }
+
+    @Test
+    void should_create_original_annotation() {
+        assertThat(
+            new Affects("properties", new Affects.ProvideDefaultValue(JsonValue.EMPTY_JSON_OBJECT))
+                .findAffectsKeywordIn(
+                    JsonSchemas.load(
+                        Json.createObjectBuilder()
+                            .add(
+                                "properties",
+                                Json.createObjectBuilder().add("test", Json.createObjectBuilder().add("type", "number"))
+                            )
+                            .build()
+                    )
+                )
+                .getValue()
+                .apply(new MockKeyword("test"))
+                .hasName("test"),
+            is(true)
+        );
+    }
+
+    @Test
+    void should_create_original_annotation_also_for_missing() {
+        assertThat(
+            new Affects("properties", new Affects.ProvideDefaultValue(JsonValue.EMPTY_JSON_OBJECT))
+                .findAffectsKeywordIn(JsonSchemas.load(JsonValue.TRUE))
+                .getValue()
+                .apply(new MockKeyword("test"))
+                .hasName("test"),
+            is(true)
+        );
+    }
+}

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/MockKeyword.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/MockKeyword.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import io.github.sebastiantoepfer.ddd.common.Media;
+import io.github.sebastiantoepfer.jsonschema.keyword.Annotation;
+import io.github.sebastiantoepfer.jsonschema.keyword.Applicator;
+import io.github.sebastiantoepfer.jsonschema.keyword.Assertion;
+import io.github.sebastiantoepfer.jsonschema.keyword.Identifier;
+import io.github.sebastiantoepfer.jsonschema.keyword.ReservedLocation;
+import jakarta.json.JsonValue;
+import java.net.URI;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Objects;
+
+final class MockKeyword implements Identifier, Assertion, Annotation, Applicator, ReservedLocation {
+
+    private final String name;
+
+    public MockKeyword(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public URI asUri() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean isValidFor(final JsonValue instance) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public JsonValue valueFor(final JsonValue value) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean applyTo(final JsonValue instance) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Collection<KeywordCategory> categories() {
+        return EnumSet.allOf(KeywordCategory.class);
+    }
+
+    @Override
+    public boolean hasName(final String name) {
+        return Objects.equals(this.name, name);
+    }
+
+    @Override
+    public <T extends Media<T>> T printOn(final T media) {
+        return media.withValue(name, name);
+    }
+}

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/ReplacingKeywordTest.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/keyword/type/ReplacingKeywordTest.java
@@ -1,0 +1,176 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 sebastian.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.sebastiantoepfer.jsonschema.core.keyword.type;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.sebastiantoepfer.ddd.media.core.HashMapMedia;
+import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
+import io.github.sebastiantoepfer.jsonschema.keyword.Keyword.KeywordCategory;
+import java.util.EnumSet;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ReplacingKeywordTest {
+
+    @Test
+    void should_not_be_createable_as_identifier_if_it_should_replace_it() {
+        final Keyword keyword = new ReplacingKeyword(
+            new MockKeyword("test"),
+            EnumSet.of(Keyword.KeywordCategory.IDENTIFIER)
+        );
+        assertThrows(UnsupportedOperationException.class, () -> keyword.asIdentifier());
+    }
+
+    @Test
+    void should_return_identifier_if_it_should_not_replaced() {
+        final Keyword keyword = new MockKeyword("test");
+        assertThat(
+            new ReplacingKeyword(
+                keyword,
+                EnumSet.complementOf(EnumSet.of(Keyword.KeywordCategory.IDENTIFIER))
+            ).asIdentifier(),
+            is(sameInstance(keyword))
+        );
+    }
+
+    @Test
+    void should_not_be_createable_as_assertion_if_it_should_replace_it() {
+        final Keyword keyword = new ReplacingKeyword(
+            new MockKeyword("test"),
+            EnumSet.of(Keyword.KeywordCategory.ASSERTION)
+        );
+        assertThrows(UnsupportedOperationException.class, () -> keyword.asAssertion());
+    }
+
+    @Test
+    void should_return_assertion_if_it_should_not_replaced() {
+        final Keyword keyword = new MockKeyword("test");
+        assertThat(
+            new ReplacingKeyword(
+                keyword,
+                EnumSet.complementOf(EnumSet.of(Keyword.KeywordCategory.ASSERTION))
+            ).asAssertion(),
+            is(sameInstance(keyword))
+        );
+    }
+
+    @Test
+    void should_not_be_createable_as_annotation_if_it_should_replace_it() {
+        final Keyword keyword = new ReplacingKeyword(
+            new MockKeyword("test"),
+            EnumSet.of(Keyword.KeywordCategory.ANNOTATION)
+        );
+        assertThrows(UnsupportedOperationException.class, () -> keyword.asAnnotation());
+    }
+
+    @Test
+    void should_return_annotation_if_it_should_not_replaced() {
+        final Keyword keyword = new MockKeyword("test");
+        assertThat(
+            new ReplacingKeyword(
+                keyword,
+                EnumSet.complementOf(EnumSet.of(Keyword.KeywordCategory.ANNOTATION))
+            ).asAnnotation(),
+            is(sameInstance(keyword))
+        );
+    }
+
+    @Test
+    void should_not_be_createable_as_applicator_if_it_should_replace_it() {
+        final Keyword keyword = new ReplacingKeyword(
+            new MockKeyword("test"),
+            EnumSet.of(Keyword.KeywordCategory.APPLICATOR)
+        );
+        assertThrows(UnsupportedOperationException.class, () -> keyword.asApplicator());
+    }
+
+    @Test
+    void should_return_applicator_if_it_should_not_replaced() {
+        final Keyword keyword = new MockKeyword("test");
+        assertThat(
+            new ReplacingKeyword(
+                keyword,
+                EnumSet.complementOf(EnumSet.of(Keyword.KeywordCategory.APPLICATOR))
+            ).asApplicator(),
+            is(sameInstance(keyword))
+        );
+    }
+
+    @Test
+    void should_not_be_createable_as_reserved_location_if_it_should_replace_it() {
+        final Keyword keyword = new ReplacingKeyword(
+            new MockKeyword("test"),
+            EnumSet.of(Keyword.KeywordCategory.RESERVED_LOCATION)
+        );
+        assertThrows(UnsupportedOperationException.class, () -> keyword.asReservedLocation());
+    }
+
+    @Test
+    void should_return_reserved_location_if_it_should_not_replaced() {
+        final Keyword keyword = new MockKeyword("test");
+        assertThat(
+            new ReplacingKeyword(
+                keyword,
+                EnumSet.complementOf(EnumSet.of(Keyword.KeywordCategory.RESERVED_LOCATION))
+            ).asReservedLocation(),
+            is(sameInstance(keyword))
+        );
+    }
+
+    @Test
+    void should_name_of_decoded_keyword() {
+        final Keyword keyword = new ReplacingKeyword(new MockKeyword("test"));
+
+        assertThat(keyword.hasName("test"), is(true));
+        assertThat(keyword.hasName("bunny"), is(false));
+    }
+
+    @Test
+    void should_print_as_decored_keyword() {
+        assertThat(
+            new ReplacingKeyword(new MockKeyword("test")).printOn(new HashMapMedia()),
+            Matchers.hasEntry("test", "test")
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(KeywordCategory.class)
+    void should_not_return_replaced_keyword_category(final Keyword.KeywordCategory category) {
+        assertThat(
+            new ReplacingKeyword(new MockKeyword("test"), EnumSet.of(category)).categories(),
+            both(not(hasItem(category))).and((Matcher) is(not(empty())))
+        );
+    }
+}

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ContainsKeywordTest.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/vocab/applicator/ContainsKeywordTest.java
@@ -30,14 +30,13 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
 import io.github.sebastiantoepfer.ddd.media.core.HashMapMedia;
+import io.github.sebastiantoepfer.jsonschema.JsonSchemas;
 import io.github.sebastiantoepfer.jsonschema.core.DefaultJsonSchemaFactory;
-import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectedByKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.SubSchemaKeywordType;
 import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
-import java.util.List;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -56,10 +55,7 @@ class ContainsKeywordTest {
 
     @Test
     void should_know_his_name() {
-        final Keyword enumKeyword = new ContainsKeyword(
-            List.of(),
-            new DefaultJsonSchemaFactory().create(JsonValue.TRUE)
-        );
+        final Keyword enumKeyword = new ContainsKeyword(JsonSchemas.load(JsonValue.TRUE));
 
         assertThat(enumKeyword.hasName("contains"), is(true));
         assertThat(enumKeyword.hasName("test"), is(false));
@@ -83,21 +79,6 @@ class ContainsKeywordTest {
             )
                 .asApplicator()
                 .applyTo(JsonValue.EMPTY_JSON_OBJECT),
-            is(true)
-        );
-    }
-
-    @Test
-    void should_apply_to_empty_array_if_min_andor_max_provided() {
-        assertThat(
-            createKeywordFrom(
-                Json.createObjectBuilder()
-                    .add("contains", Json.createObjectBuilder().add("type", "number"))
-                    .add("minContains", 0)
-                    .build()
-            )
-                .asApplicator()
-                .applyTo(JsonValue.EMPTY_JSON_ARRAY),
             is(true)
         );
     }
@@ -232,10 +213,8 @@ class ContainsKeywordTest {
     }
 
     private static Keyword createKeywordFrom(final JsonObject json) {
-        return new AffectedByKeywordType(
-            "contains",
-            List.of("minContains", "maxContains"),
-            (a, schema) -> new SubSchemaKeywordType("contains", s -> new ContainsKeyword(a, s)).createKeyword(schema)
-        ).createKeyword(new DefaultJsonSchemaFactory().create(json));
+        return new SubSchemaKeywordType("contains", ContainsKeyword::new).createKeyword(
+            new DefaultJsonSchemaFactory().create(json)
+        );
     }
 }

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/MaxContainsKeywordTest.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/MaxContainsKeywordTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 
 import io.github.sebastiantoepfer.ddd.media.core.HashMapMedia;
 import io.github.sebastiantoepfer.jsonschema.core.DefaultJsonSchemaFactory;
+import io.github.sebastiantoepfer.jsonschema.core.keyword.type.Affects;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectsKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.IntegerKeywordType;
 import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
@@ -38,6 +39,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import jakarta.json.spi.JsonProvider;
 import java.math.BigInteger;
+import java.util.List;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +47,10 @@ class MaxContainsKeywordTest {
 
     @Test
     void should_know_his_name() {
-        final Keyword enumKeyword = new MaxContainsKeyword(new StaticAnnotation("", JsonValue.NULL), BigInteger.ONE);
+        final Keyword enumKeyword = new MaxContainsKeyword(
+            List.of(new StaticAnnotation("", JsonValue.NULL)),
+            BigInteger.ONE
+        );
         assertThat(enumKeyword.hasName("maxContains"), is(true));
         assertThat(enumKeyword.hasName("test"), is(false));
     }
@@ -61,19 +66,14 @@ class MaxContainsKeywordTest {
     @Test
     void should_be_valid_for_non_arrays() {
         assertThat(
-            createKeywordFrom(Json.createObjectBuilder().add("maxContains", 2).build())
+            createKeywordFrom(
+                Json.createObjectBuilder()
+                    .add("contains", Json.createObjectBuilder().add("type", "string"))
+                    .add("maxContains", 2)
+                    .build()
+            )
                 .asAssertion()
                 .isValidFor(JsonValue.EMPTY_JSON_OBJECT),
-            is(true)
-        );
-    }
-
-    @Test
-    void should_be_valid_if_no_contains_is_present() {
-        assertThat(
-            createKeywordFrom(Json.createObjectBuilder().add("maxContains", 2).build())
-                .asAssertion()
-                .isValidFor(Json.createArrayBuilder().add("foo").build()),
             is(true)
         );
     }
@@ -186,7 +186,7 @@ class MaxContainsKeywordTest {
     private static Keyword createKeywordFrom(final JsonObject json) {
         return new AffectsKeywordType(
             "maxContains",
-            "contains",
+            List.of(new Affects("contains", new Affects.ReplaceKeyword())),
             (a, s) ->
                 new IntegerKeywordType(
                     JsonProvider.provider(),

--- a/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/MinContainsKeywordTest.java
+++ b/core/src/test/java/io/github/sebastiantoepfer/jsonschema/core/vocab/validation/MinContainsKeywordTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 
 import io.github.sebastiantoepfer.ddd.media.core.HashMapMedia;
 import io.github.sebastiantoepfer.jsonschema.core.DefaultJsonSchemaFactory;
+import io.github.sebastiantoepfer.jsonschema.core.keyword.type.Affects;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.AffectsKeywordType;
 import io.github.sebastiantoepfer.jsonschema.core.keyword.type.IntegerKeywordType;
 import io.github.sebastiantoepfer.jsonschema.keyword.Keyword;
@@ -38,6 +39,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import jakarta.json.spi.JsonProvider;
 import java.math.BigInteger;
+import java.util.List;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +47,10 @@ class MinContainsKeywordTest {
 
     @Test
     void should_know_his_name() {
-        final Keyword enumKeyword = new MinContainsKeyword(new StaticAnnotation("", JsonValue.NULL), BigInteger.ONE);
+        final Keyword enumKeyword = new MinContainsKeyword(
+            List.of(new StaticAnnotation("", JsonValue.NULL)),
+            BigInteger.ONE
+        );
 
         assertThat(enumKeyword.hasName("minContains"), is(true));
         assertThat(enumKeyword.hasName("test"), is(false));
@@ -62,19 +67,14 @@ class MinContainsKeywordTest {
     @Test
     void should_be_valid_for_non_arrays() {
         assertThat(
-            createKeywordFrom(Json.createObjectBuilder().add("minContains", 2).build())
+            createKeywordFrom(
+                Json.createObjectBuilder()
+                    .add("contains", Json.createObjectBuilder().add("type", "string"))
+                    .add("minContains", 2)
+                    .build()
+            )
                 .asAssertion()
                 .isValidFor(JsonValue.EMPTY_JSON_OBJECT),
-            is(true)
-        );
-    }
-
-    @Test
-    void should_be_valid_if_no_contains_is_present() {
-        assertThat(
-            createKeywordFrom(Json.createObjectBuilder().add("minContains", 2).build())
-                .asAssertion()
-                .isValidFor(Json.createArrayBuilder().add("foo").build()),
             is(true)
         );
     }
@@ -187,7 +187,7 @@ class MinContainsKeywordTest {
     private static Keyword createKeywordFrom(final JsonObject json) {
         return new AffectsKeywordType(
             "minContains",
-            "contains",
+            List.of(new Affects("contains", new Affects.ReplaceKeyword())),
             (a, s) ->
                 new IntegerKeywordType(
                     JsonProvider.provider(),


### PR DESCRIPTION
The current implementation is very limited. To change the functionality of a relationship, the keywords themselves must be changed (violation of the Openclose principle).

## AffectedBy
AffectedBy defines a relationship where the output is affected by the defined keywords. In most cases, this means that a “true” can be changed to a “false” (e.g. maxContains for contains) or simply defines which data the keyword affects (e.g. additionalProperties uses properties and patternProperties). In some cases, however, the presence of the other keyword means that the keyword in question can deliver neither true nor false (e.g. minContains for contains).
To solve this problem without completely linking the keywords, we define the type of relationship (`AffectByType`).
**AffectType**:
*Extends* means that the keyword is fully evaluated, but the true output can be affected by another keyword and changed to false.
*Replace* means that the keyword is not evaluated (neither as an applicator nor as an assertion), but the other keyword takes over completely.

sample for contains Keyword:
```java
new AffectedByKeywordType(
    ContainsKeyword.NAME,
    List.of(
        new AffectedBy(AffectByType.REPLACE, "minContains"),
        new AffectedBy(AffectByType.EXTENDS, "maxContains")
    ),
    new SubSchemaKeywordType(ContainsKeyword.NAME, ContainsKeyword::new)::createKeyword
)
```

## Affects
Affects defines keywords that are modified by this keyword. In most cases, the absence of this keyword is not a big problem, but for some it means that the other is not needed (e.g. minContains has no meaning without contains)
Solution Affects becomes a default value if keyword is absent.