### PR TITLE
remove reduntant configuration from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,43 +107,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <defaultGoal>install</defaultGoal>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.cyclonedx</groupId>
-                    <artifactId>cyclonedx-maven-plugin</artifactId>
-                    <version>2.8.0</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>makeAggregateBom</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <projectType>library</projectType>
-                        <includeProvidedScope>false</includeProvidedScope>
-                        <includeRuntimeScope>false</includeRuntimeScope>
-                        <includeSystemScope>false</includeSystemScope>
-                        <includeLicenseText>false</includeLicenseText>
-                        <outputFormat>all</outputFormat>
-                        <outputName>sbom</outputName>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.cyclonedx</groupId>
-                <artifactId>cyclonedx-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>ci</id>


### PR DESCRIPTION
is already defined in parent, so we must no longer maintain it yourself.